### PR TITLE
fix(reviewer-bot): honor repository uv pin

### DIFF
--- a/.github/workflows/build-guidelines.yml
+++ b/.github/workflows/build-guidelines.yml
@@ -38,6 +38,7 @@ jobs:
           tests/unit/fls_audit
           tests/integration/fls_audit
           tests/contract/fls_audit
+          tests/contract/tooling
 
   build:
     needs:

--- a/.github/workflows/reviewer-bot-issue-comment-direct.yml
+++ b/.github/workflows/reviewer-bot-issue-comment-direct.yml
@@ -21,8 +21,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -30,6 +28,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/.github/workflows/reviewer-bot-issues.yml
+++ b/.github/workflows/reviewer-bot-issues.yml
@@ -20,8 +20,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -29,6 +27,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/.github/workflows/reviewer-bot-pr-comment-router.yml
+++ b/.github/workflows/reviewer-bot-pr-comment-router.yml
@@ -26,8 +26,6 @@ jobs:
       comment_author_id: ${{ steps.route.outputs.comment_author_id }}
       reviewer_bot_trust_class: ${{ steps.route.outputs.reviewer_bot_trust_class }}
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -35,6 +33,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Route PR comment
         id: route
         env:
@@ -192,8 +194,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -201,6 +201,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/.github/workflows/reviewer-bot-pr-metadata.yml
+++ b/.github/workflows/reviewer-bot-pr-metadata.yml
@@ -20,8 +20,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -29,6 +27,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/.github/workflows/reviewer-bot-preview.yml
+++ b/.github/workflows/reviewer-bot-preview.yml
@@ -34,8 +34,6 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -43,6 +41,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot preview
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/.github/workflows/reviewer-bot-privileged-commands.yml
+++ b/.github/workflows/reviewer-bot-privileged-commands.yml
@@ -26,11 +26,13 @@ jobs:
     steps:
       - name: Checkout trusted default-branch bot code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Install uv
-        run: python -m pip install uv
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Document isolated privileged execution boundary
         run: |
           {

--- a/.github/workflows/reviewer-bot-reconcile.yml
+++ b/.github/workflows/reviewer-bot-reconcile.yml
@@ -25,8 +25,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Download deferred artifact
         continue-on-error: true
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -42,6 +40,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Select deferred payload
         run: |
           python - <<'PY'

--- a/.github/workflows/reviewer-bot-sweeper-repair.yml
+++ b/.github/workflows/reviewer-bot-sweeper-repair.yml
@@ -38,8 +38,6 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - name: Install uv
-        run: python -m pip install uv
       - name: Checkout trusted bot source
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -47,6 +45,10 @@ jobs:
       - name: Select trusted bot source
         id: bot-source
         uses: ./.github/actions/reviewer-bot-source
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version-file: pyproject.toml
       - name: Run reviewer bot
         env:
           BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -1,4 +1,5 @@
 import json
+import re
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -425,7 +426,7 @@ def test_reviewer_bot_workflows_use_shared_source_action_without_raw_extraction(
 
 
 def test_operational_reviewer_bot_jobs_install_uv_from_trusted_project_pin():
-    expected_jobs = {
+    operational_uv_jobs = {
         ("reviewer-bot-issue-comment-direct.yml", "reviewer-bot-issue-comment-direct"),
         ("reviewer-bot-issues.yml", "reviewer-bot-issues"),
         ("reviewer-bot-pr-comment-router.yml", "route-pr-comment"),
@@ -436,54 +437,71 @@ def test_operational_reviewer_bot_jobs_install_uv_from_trusted_project_pin():
         ("reviewer-bot-reconcile.yml", "reconcile"),
         ("reviewer-bot-sweeper-repair.yml", "reviewer-bot-sweeper-repair"),
     }
-    covered_jobs = set()
+    ci_uv_jobs = {
+        ("reviewer-bot-tests.yml", "reviewer-bot-contract"),
+        ("reviewer-bot-tests.yml", "reviewer-bot-coverage"),
+        ("reviewer-bot-tests.yml", "reviewer-bot-integration"),
+        ("reviewer-bot-tests.yml", "reviewer-bot-unit"),
+    }
+    uv_token = re.compile(r"\buvx?\b")
+    workflow_jobs: dict[tuple[str, str], dict] = {}
+    discovered_uv_jobs = set()
 
     for path in sorted(Path(".github/workflows").glob("reviewer-bot-*.yml")):
         workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
         for job_name, job in workflow.get("jobs", {}).items():
+            job_key = (path.name, job_name)
+            workflow_jobs[job_key] = job
             steps = job.get("steps", [])
-            execution_indexes = [
-                index
-                for index, step in enumerate(steps)
-                if 'uv run --project "$BOT_SRC_ROOT"' in str(step.get("run", ""))
-            ]
-            if not execution_indexes:
-                continue
+            if any(
+                uv_token.search(str(step.get("uses", "")))
+                or uv_token.search(str(step.get("run", "")))
+                for step in steps
+            ):
+                discovered_uv_jobs.add(job_key)
 
-            covered_jobs.add((path.name, job_name))
-            checkout_indexes = [
-                index
-                for index, step in enumerate(steps)
-                if str(step.get("uses", "")).startswith("actions/checkout@")
-            ]
-            source_indexes = [
-                index
-                for index, step in enumerate(steps)
-                if step.get("uses") == "./.github/actions/reviewer-bot-source"
-            ]
-            setup_indexes = [
-                index
-                for index, step in enumerate(steps)
-                if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
-            ]
+    assert discovered_uv_jobs == operational_uv_jobs | ci_uv_jobs
 
-            assert len(checkout_indexes) == 1
-            assert len(source_indexes) == 1
-            assert len(setup_indexes) == 1
-            assert len(execution_indexes) == 1
-            assert checkout_indexes[0] < source_indexes[0] < setup_indexes[0] < execution_indexes[0]
+    for job_key in sorted(operational_uv_jobs):
+        steps = workflow_jobs[job_key].get("steps", [])
+        checkout_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        source_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == "./.github/actions/reviewer-bot-source"
+        ]
+        setup_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+        ]
+        uv_shell_lines = [
+            (index, line.strip())
+            for index, step in enumerate(steps)
+            for line in str(step.get("run", "")).splitlines()
+            if uv_token.search(line)
+        ]
 
-            checkout = steps[checkout_indexes[0]]
-            setup = steps[setup_indexes[0]]
-            assert "path" not in checkout.get("with", {})
-            setup_action, setup_sha = setup["uses"].split("@", 1)
-            assert setup_action == "astral-sh/setup-uv"
-            assert len(setup_sha) == 40
-            int(setup_sha, 16)
-            assert setup.get("with") == {"version-file": "pyproject.toml"}
-            assert all("python -m pip install uv" not in str(step.get("run", "")) for step in steps)
+        assert len(checkout_indexes) == 1
+        assert len(source_indexes) == 1
+        assert len(setup_indexes) == 1
+        assert len(uv_shell_lines) == 1
+        execution_index, execution_line = uv_shell_lines[0]
+        assert len(uv_token.findall(execution_line)) == 1
+        assert re.match(r'^uv\s+run\s+--project\s+"\$BOT_SRC_ROOT"(?:\s|$)', execution_line)
+        assert checkout_indexes[0] < source_indexes[0] < setup_indexes[0] < execution_index
 
-    assert covered_jobs == expected_jobs
+        checkout = steps[checkout_indexes[0]]
+        setup = steps[setup_indexes[0]]
+        assert "path" not in checkout.get("with", {})
+        setup_action, setup_sha = setup["uses"].split("@", 1)
+        assert setup_action == "astral-sh/setup-uv"
+        assert re.fullmatch(r"[0-9a-f]{40}", setup_sha)
+        assert setup.get("with") == {"version-file": "pyproject.toml"}
 
 
 def test_reviewer_bot_source_action_validates_checkout_provenance():

--- a/tests/contract/reviewer_bot/test_workflow_files.py
+++ b/tests/contract/reviewer_bot/test_workflow_files.py
@@ -328,14 +328,14 @@ def test_pr_comment_router_workflow_contains_route_and_trusted_jobs_in_order():
     assert set(data["jobs"]) == {"route-pr-comment", "trusted-direct"}
     route_steps = data["jobs"]["route-pr-comment"]["steps"]
     trusted_steps = data["jobs"]["trusted-direct"]["steps"]
-    assert route_steps[0]["name"] == "Install uv"
-    assert route_steps[1]["name"] == "Checkout trusted bot source"
-    assert route_steps[2]["name"] == "Select trusted bot source"
+    assert route_steps[0]["name"] == "Checkout trusted bot source"
+    assert route_steps[1]["name"] == "Select trusted bot source"
+    assert route_steps[2]["name"] == "Install uv"
     assert route_steps[3]["name"] == "Route PR comment"
     assert route_steps[4]["name"] == "Upload deferred comment artifact"
-    assert trusted_steps[0]["name"] == "Install uv"
-    assert trusted_steps[1]["name"] == "Checkout trusted bot source"
-    assert trusted_steps[2]["name"] == "Select trusted bot source"
+    assert trusted_steps[0]["name"] == "Checkout trusted bot source"
+    assert trusted_steps[1]["name"] == "Select trusted bot source"
+    assert trusted_steps[2]["name"] == "Install uv"
     assert trusted_steps[3]["name"] == "Run reviewer bot"
 
 def test_pr_comment_router_upload_is_emitted_only_for_deferred_reconcile():
@@ -422,6 +422,68 @@ def test_reviewer_bot_workflows_use_shared_source_action_without_raw_extraction(
         if 'uv run --project "$BOT_SRC_ROOT"' in text or 'python "$BOT_SRC_ROOT/scripts/reviewer_bot.py"' in text:
             assert "uses: ./.github/actions/reviewer-bot-source" in text
             assert "BOT_SRC_ROOT: ${{ steps.bot-source.outputs.bot-src-root }}" in text
+
+
+def test_operational_reviewer_bot_jobs_install_uv_from_trusted_project_pin():
+    expected_jobs = {
+        ("reviewer-bot-issue-comment-direct.yml", "reviewer-bot-issue-comment-direct"),
+        ("reviewer-bot-issues.yml", "reviewer-bot-issues"),
+        ("reviewer-bot-pr-comment-router.yml", "route-pr-comment"),
+        ("reviewer-bot-pr-comment-router.yml", "trusted-direct"),
+        ("reviewer-bot-pr-metadata.yml", "reviewer-bot-pr-metadata"),
+        ("reviewer-bot-preview.yml", "reviewer-bot-preview"),
+        ("reviewer-bot-privileged-commands.yml", "privileged-command-executor"),
+        ("reviewer-bot-reconcile.yml", "reconcile"),
+        ("reviewer-bot-sweeper-repair.yml", "reviewer-bot-sweeper-repair"),
+    }
+    covered_jobs = set()
+
+    for path in sorted(Path(".github/workflows").glob("reviewer-bot-*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in workflow.get("jobs", {}).items():
+            steps = job.get("steps", [])
+            execution_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if 'uv run --project "$BOT_SRC_ROOT"' in str(step.get("run", ""))
+            ]
+            if not execution_indexes:
+                continue
+
+            covered_jobs.add((path.name, job_name))
+            checkout_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if str(step.get("uses", "")).startswith("actions/checkout@")
+            ]
+            source_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if step.get("uses") == "./.github/actions/reviewer-bot-source"
+            ]
+            setup_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+            ]
+
+            assert len(checkout_indexes) == 1
+            assert len(source_indexes) == 1
+            assert len(setup_indexes) == 1
+            assert len(execution_indexes) == 1
+            assert checkout_indexes[0] < source_indexes[0] < setup_indexes[0] < execution_indexes[0]
+
+            checkout = steps[checkout_indexes[0]]
+            setup = steps[setup_indexes[0]]
+            assert "path" not in checkout.get("with", {})
+            setup_action, setup_sha = setup["uses"].split("@", 1)
+            assert setup_action == "astral-sh/setup-uv"
+            assert len(setup_sha) == 40
+            int(setup_sha, 16)
+            assert setup.get("with") == {"version-file": "pyproject.toml"}
+            assert all("python -m pip install uv" not in str(step.get("run", "")) for step in steps)
+
+    assert covered_jobs == expected_jobs
 
 
 def test_reviewer_bot_source_action_validates_checkout_provenance():

--- a/tests/contract/tooling/test_uv_bootstrap.py
+++ b/tests/contract/tooling/test_uv_bootstrap.py
@@ -1,0 +1,95 @@
+"""Repository-wide uv bootstrap contract."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.contract
+
+WORKFLOWS_DIR = Path(".github/workflows")
+WORKFLOWS = sorted([*WORKFLOWS_DIR.glob("*.yml"), *WORKFLOWS_DIR.glob("*.yaml")])
+UV_COMMAND = re.compile(
+    r"(?:^|&&|\|\||[;|()])\s*"
+    r"(?:(?:if|then|do|command|exec|env|sudo|!)\s+)*"
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*uvx?\b"
+)
+FORBIDDEN_BOOTSTRAP = re.compile(
+    r"\bpip(?:3|x)?\b[^\n]*\binstall\b[^\n]*\buv\b"
+    r"|astral\.sh/uv"
+    r"|\buv\s+self\s+update\b",
+    re.IGNORECASE,
+)
+
+
+def jobs():
+    for path in WORKFLOWS:
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            yield path.name, job_name, job
+
+
+def run_invokes_uv(run: str) -> bool:
+    for line in run.splitlines():
+        command = line.lstrip()
+        if command.startswith(("#", "echo ", "printf ")):
+            continue
+        if UV_COMMAND.search(line):
+            return True
+    return False
+
+
+def test_every_setup_uv_step_follows_a_root_checkout_in_the_same_job():
+    violations = []
+    for file_name, job_name, job in jobs():
+        steps = job.get("steps") or []
+        root_checkout_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+            and str((step.get("with") or {}).get("path", ".")).strip() in {"", "."}
+        ]
+        for setup_index, step in enumerate(steps):
+            if not str(step.get("uses", "")).startswith("astral-sh/setup-uv@"):
+                continue
+            if not any(checkout_index < setup_index for checkout_index in root_checkout_indexes):
+                violations.append(f"{file_name}:{job_name} step {setup_index}")
+    assert not violations, f"setup-uv runs before a workspace-root checkout: {violations}"
+
+
+def test_setup_uv_never_overrides_the_repository_pin():
+    violations = []
+    for file_name, job_name, job in jobs():
+        for step in job.get("steps") or []:
+            if not str(step.get("uses", "")).startswith("astral-sh/setup-uv@"):
+                continue
+            with_ = step.get("with") or {}
+            if "version" in with_:
+                violations.append(f"{file_name}:{job_name} version={with_['version']!r}")
+            if with_.get("version-file", "pyproject.toml") != "pyproject.toml":
+                violations.append(f"{file_name}:{job_name} version-file={with_['version-file']!r}")
+    assert not violations, f"setup-uv must take the version from pyproject.toml only: {violations}"
+
+
+def test_no_workflow_installs_uv_outside_setup_uv():
+    violations = []
+    for file_name, job_name, job in jobs():
+        for index, step in enumerate(job.get("steps") or []):
+            run = str(step.get("run", "")).replace("\\\n", " ")
+            if FORBIDDEN_BOOTSTRAP.search(run):
+                violations.append(f"{file_name}:{job_name} step {index}")
+    assert not violations, f"uv must be installed only via astral-sh/setup-uv: {violations}"
+
+
+def test_every_job_that_runs_uv_installs_it_via_setup_uv():
+    violations = []
+    for file_name, job_name, job in jobs():
+        steps = job.get("steps") or []
+        runs_uv = any(run_invokes_uv(str(step.get("run", ""))) for step in steps)
+        has_setup = any(
+            str(step.get("uses", "")).startswith("astral-sh/setup-uv@") for step in steps
+        )
+        if runs_uv and not has_setup:
+            violations.append(f"{file_name}:{job_name}")
+    assert not violations, f"jobs run uv without a setup-uv step: {violations}"


### PR DESCRIPTION
## Summary

- restore the nine operational reviewer-bot jobs broken when the repository uv pin exposed their unpinned bootstrap
- install uv only after trusted-source checkout and validation, using an immutable `setup-uv` action and the trusted checkout's `pyproject.toml`
- add required repository-wide contracts preventing pre-checkout setup, version overrides, alternate installers, and uv execution without setup

## Root Cause

#1239 added `required-version = "==0.12.6"` to `pyproject.toml`. The operational reviewer-bot workflows installed the latest uv release through `pip` before checkout, so they received uv 0.12.8. Every subsequent `uv run` then rejected the version mismatch before the bot executed.

The other 14 `setup-uv` jobs remained green because they checkout the repository before setup, allowing the action to discover the repository pin. That ordering was correct but previously unenforced.

## Fix

The nine operational jobs now:

1. Checkout the trusted default-branch source.
2. Validate its provenance with the existing reviewer-bot source action.
3. Install uv through SHA-pinned `setup-uv` v6.8.0.
4. Read the uv version from the validated checkout's `pyproject.toml`.
5. Execute the existing reviewer-bot command unchanged.

A repository-wide contract now requires every workflow to:

- perform a workspace-root checkout before `setup-uv`;
- derive the uv version from `pyproject.toml`;
- avoid pip, pipx, shell-installer, and `uv self update` bootstrap paths;
- use `setup-uv` in every job that executes uv or uvx.

The contract is included in the required `build` check. No bot Python logic, permissions, event triggers, `pyproject.toml`, or `uv.lock` changed.

## Testing

- `uv run ruff check --fix`
- `uv lock --check`
- reviewer-bot workflow contract: `47 passed`
- reviewer-bot contract suite: `270 passed`
- repository tooling contracts: `4 passed`
- all contract tests: `278 passed`
- required-build test invocation: `162 passed`
- full repository suite: `1202 passed`
- Actionlint on all nine changed workflows
- mutation matrix covering pre-checkout setup, nested checkout, version override, alternate installation, bare uv execution, and piped uv execution

## Operational Notes

The initial `Reviewer Bot PR Metadata` run is expected to fail because `pull_request_target` uses the currently broken workflow from the default branch. That failure does not exercise this branch's corrected workflow.

After merge:

1. Verify the fixed PR close-event workflow.
2. Preview the status-label projection for #1219.
3. Preview issue #314 state health.
4. Dispatch only the targeted repairs indicated by those previews.
5. Repeat the previews and retain the workflow artifacts.

Repository-wide Actionlint still reports the existing `actions/checkout@v3` use in `.github/workflows/coding-guideline-issue-labeler.yml`. This PR intentionally does not expand into that unrelated workflow.
